### PR TITLE
Introduce matador, and the concept of trading strategies

### DIFF
--- a/cmd/example/example.go
+++ b/cmd/example/example.go
@@ -39,7 +39,7 @@ func main() {
 
 	sym := "SPY"
 	log.Printf("Looking up %s ...", sym)
-	i, err := r.Lookup(ctx, sym)
+	i, err := r.Instrument(ctx, sym)
 	if err != nil {
 		log.Fatalf("get instrument failed: %v", err)
 	}
@@ -59,11 +59,11 @@ func main() {
 		log.Printf("  %s: opened at %.2f, closed at %.2f", r.BeginsAt, r.OpenPrice, r.ClosePrice)
 	}
 
-	qs, err := r.Quote(ctx, "SPY")
+	q, err := r.Quote(ctx, "SPY")
 	if err != nil {
 		log.Fatalf("get quote failed: %v", err)
 	}
-	log.Printf("SPY current price is $%.2f", qs[0].Price())
+	log.Printf("SPY current price is $%.2f", q.Price())
 
 	if len(os.Args) == 1 {
 		return

--- a/cmd/matador/matador.go
+++ b/cmd/matador/matador.go
@@ -97,22 +97,15 @@ func loop(ctx context.Context, r *roho.Client, st strategy.Strategy, syms []stri
 	for {
 		klog.Infof("sleeping for %s ...", *minPollFlag)
 		time.Sleep(*minPollFlag)
-		klog.Infof("gathering quotes for %d symbols ...", len(syms))
 
-		qs, err := r.Quotes(ctx, syms)
+		// TODO: update instead of rebuild
+		combined, err := strategy.LiveData(ctx, r, syms)
 		if err != nil {
-			klog.Errorf("failed to quote instruments: %v", err)
+			klog.Errorf("live data failed: %v", err)
 			continue
 		}
 
-		ps, err := r.Positions(ctx)
-		if err != nil {
-			klog.Errorf("failed to get positions: %v", err)
-		}
-
-		klog.Infof("calculating trades for %d positions ...", len(ps))
-
-		ts, err := st.Trades(ctx, ps, qs)
+		ts, err := st.Trades(ctx, combined)
 		if err != nil {
 			klog.Errorf("trades failed: %v", err)
 			continue

--- a/cmd/matador/matador.go
+++ b/cmd/matador/matador.go
@@ -7,43 +7,155 @@ package main
 
 import (
 	"context"
-	"log"
+	"flag"
+	"fmt"
 	"os"
 	"time"
 
+	"github.com/tstromberg/roho/pkg/index"
 	"github.com/tstromberg/roho/pkg/roho"
 	"github.com/tstromberg/roho/pkg/strategy"
+	"k8s.io/klog/v2"
+)
+
+var (
+	dryRunFlag          = flag.Bool("dry-run", false, "dry-run mode (don't buy/sell anything)")
+	strategyFlag        = flag.String("strategy", "", fmt.Sprintf("strategy to use. Choices: %v", strategy.List()))
+	minPollFlag         = flag.Duration("min-poll", 5*time.Second, "minimum time to poll (even if errors happen)")
+	maxPollFlag         = flag.Duration("max-poll", 60*time.Second, "maximum time to poll")
+	maxBuysFlag         = flag.Int("max-buys", 1000, "maximum buys before exiting")
+	maxBuysPerPollFlag  = flag.Int("max-buys-per-poll", 1, "maximum buys per polling period")
+	maxSalesFlag        = flag.Int("max-sales", 1000, "maximum sales before exiting")
+	maxSalesPerPollFlag = flag.Int("max-sales-per-poll", 1, "maximum sales per polling period")
 )
 
 func main() {
+	klog.InitFlags(nil)
+	flag.Parse()
+
 	ctx := context.Background()
 	r, err := roho.New(ctx, &roho.Config{})
 	if err != nil {
-		log.Fatalf("new failed: %v", err)
+		klog.Fatalf("new failed: %v", err)
 	}
 
-	if len(os.Args) < 3 {
-		log.Fatalf("syntax: matador [strategy] [symbols]")
+	klog.Infof("args=%v (dry-run=%v, strategy=%v)", os.Args, *dryRunFlag, *strategyFlag)
+
+	if len(flag.Args()) < 1 {
+		klog.Fatalf("usage: matador --strategy=X [symbols]")
 	}
 
-	symbols := os.Args[2:]
-
-	cr, err := strategy.New(ctx, strategy.Config{Client: r, Kind: os.Args[1]})
+	syms, err := index.Resolve(flag.Args())
 	if err != nil {
-		log.Fatalf("strategy failed: %v", err)
+		klog.Fatalf("failed to resolve symbols: %v", err)
 	}
+
+	if len(syms) == 0 {
+		klog.Errorf("no symbols were resolved. usage: matador --strategy=X [symbols]")
+		os.Exit(1)
+	}
+
+	st, err := strategy.New(ctx, strategy.Config{Client: r, Kind: *strategyFlag})
+	if err != nil {
+		klog.Errorf("strategy failed: %v", err)
+		os.Exit(1)
+	}
+
+	loop(ctx, r, st, syms)
+}
+
+func trade(ctx context.Context, r *roho.Client, t strategy.Trade, dryRun bool) error {
+	act := "Selling"
+	if t.Order.Side == roho.Buy {
+		act = "Buying"
+	}
+
+	if dryRun {
+		act = "[DRY RUN] " + act
+	}
+
+	sym := t.Symbol
+	if sym == "" && t.InstrumentURL != "" {
+		i, err := r.InstrumentFromURL(ctx, t.InstrumentURL)
+		if err != nil {
+			return fmt.Errorf("instrument from URL: %w", err)
+		}
+		sym = i.Symbol
+	}
+
+	klog.Infof("%s %d shares of %q at %.2f ...", act, t.Order.Quantity, sym, t.Order.Price)
+	return nil
+}
+
+func loop(ctx context.Context, r *roho.Client, st strategy.Strategy, syms []string) {
+	totalBuys := 0
+	totalSales := 0
+	klog.Infof("%q loop has begun with %d symbols!", st, len(syms))
+
+	maxSleep := *maxPollFlag - *minPollFlag
 
 	for {
-		ts, err := cr.Trades(ctx, symbols)
+		klog.Infof("sleeping for %s ...", *minPollFlag)
+		time.Sleep(*minPollFlag)
+		klog.Infof("gathering quotes for %d symbols ...", len(syms))
+
+		qs, err := r.Quotes(ctx, syms)
 		if err != nil {
-			log.Fatalf("trades failed: %v", err)
+			klog.Errorf("failed to quote instruments: %v", err)
+			continue
 		}
 
+		ps, err := r.Positions(ctx)
+		if err != nil {
+			klog.Errorf("failed to get positions: %v", err)
+		}
+
+		klog.Infof("calculating trades for %d positions ...", len(ps))
+
+		ts, err := st.Trades(ctx, ps, qs)
+		if err != nil {
+			klog.Errorf("trades failed: %v", err)
+			continue
+		}
+
+		sales := 0
+		buys := 0
 		for _, t := range ts {
-			log.Printf("TRADE: %+v", t)
+			if t.Order.Side == roho.Buy {
+				buys++
+				totalBuys++
+				if buys > *maxBuysPerPollFlag {
+					klog.Warningf(" -> BUY %d (ignoring): %+v", t)
+					continue
+				}
+
+				if totalBuys >= *maxBuysFlag {
+					klog.Errorf("hit maximum buys (%d) - exiting", totalBuys)
+					return
+				}
+			}
+
+			if t.Order.Side == roho.Sell {
+				sales++
+				totalSales++
+
+				if sales > *maxSalesPerPollFlag {
+					klog.Warningf(" -> SELL %d (ignoring): %+v", t)
+					continue
+				}
+
+				if totalSales >= *maxSalesFlag {
+					klog.Errorf("hit maximum sales (%d) - exiting", totalSales)
+					return
+				}
+			}
+
+			if err := trade(ctx, r, t, *dryRunFlag); err != nil {
+				klog.Errorf("trade failed: %v", err)
+			}
 		}
 
-		log.Printf("Sleeping for 1 minute")
-		time.Sleep(1 * time.Minute)
+		klog.Infof("Sleeping for %s...", maxSleep)
+		time.Sleep(maxSleep)
 	}
 }

--- a/cmd/matador/matador.go
+++ b/cmd/matador/matador.go
@@ -1,0 +1,49 @@
+// Matador runs trading strategies
+package main
+
+// usage:
+//
+// RH_USER=email@example.org RH_PASS=password go run .
+
+import (
+	"context"
+	"log"
+	"os"
+	"time"
+
+	"github.com/tstromberg/roho/pkg/roho"
+	"github.com/tstromberg/roho/pkg/strategy"
+)
+
+func main() {
+	ctx := context.Background()
+	r, err := roho.New(ctx, &roho.Config{})
+	if err != nil {
+		log.Fatalf("new failed: %v", err)
+	}
+
+	if len(os.Args) < 3 {
+		log.Fatalf("syntax: matador [strategy] [symbols]")
+	}
+
+	symbols := os.Args[2:]
+
+	cr, err := strategy.New(ctx, strategy.Config{Client: r, Kind: os.Args[1]})
+	if err != nil {
+		log.Fatalf("strategy failed: %v", err)
+	}
+
+	for {
+		ts, err := cr.Trades(ctx, symbols)
+		if err != nil {
+			log.Fatalf("trades failed: %v", err)
+		}
+
+		for _, t := range ts {
+			log.Printf("TRADE: %+v", t)
+		}
+
+		log.Printf("Sleeping for 1 minute")
+		time.Sleep(1 * time.Minute)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,11 @@ module github.com/tstromberg/roho
 go 1.16
 
 require (
+	github.com/PuerkitoBio/goquery v1.7.1
 	github.com/google/uuid v1.3.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/pkg/errors v0.9.1
 	golang.org/x/oauth2 v0.0.0-20210819190943-2bc19b11175f
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
+	k8s.io/klog/v2 v2.20.0
 )

--- a/go.sum
+++ b/go.sum
@@ -33,6 +33,10 @@ cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/PuerkitoBio/goquery v1.7.1 h1:oE+T06D+1T7LNrn91B4aERsRIeCLJ/oPSa6xB9FPnz4=
+github.com/PuerkitoBio/goquery v1.7.1/go.mod h1:XY0pP4kfraEmmV1O7Uf6XyjoslwsneBbgeDjLYuN8xY=
+github.com/andybalholm/cascadia v1.2.0 h1:vuRCkM5Ozh/BfmsaTm26kbjm0mIOM3yS5Ek/F5h18aE=
+github.com/andybalholm/cascadia v1.2.0/go.mod h1:YCyR8vOZT9aZ1CHEd8ap0gMVm2aFgxBp0T0eFw1RUQY=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
@@ -47,6 +51,8 @@ github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
+github.com/go-logr/logr v1.0.0 h1:kH951GinvFVaQgy/ki/B3YYmQtRpExGigSJg6O8z5jo=
+github.com/go-logr/logr v1.0.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -159,6 +165,7 @@ golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzB
 golang.org/x/mod v0.1.1-0.20191107180719-034126e5016b/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/net v0.0.0-20180218175443-cbe0f9307d01/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -184,8 +191,9 @@ golang.org/x/net v0.0.0-20200513185701-a91f0712d120/go.mod h1:qpuaurCH72eLCgpAm/
 golang.org/x/net v0.0.0-20200520182314-0ba52f642ac2/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20200707034311-ab3426394381/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
-golang.org/x/net v0.0.0-20200822124328-c89045814202 h1:VvcQYSHwXgi7W+TpUR6A9g6Up98WAHf3f/ulnJ62IyA=
 golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
+golang.org/x/net v0.0.0-20210614182718-04defd469f4e h1:XpT3nA5TvE525Ne3hInMh6+GETgn27Zfm9dxsThnX2Q=
+golang.org/x/net v0.0.0-20210614182718-04defd469f4e/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -228,11 +236,15 @@ golang.org/x/sys v0.0.0-20200511232937-7e40ca221e25/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200515095857-1151b9dac4a9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200523222454-059865788121/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200803210538-64077c9b5642/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
@@ -367,6 +379,8 @@ honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
+k8s.io/klog/v2 v2.20.0 h1:tlyxlSvd63k7axjhuchckaRJm+a92z5GSOrTOQY5sHw=
+k8s.io/klog/v2 v2.20.0/go.mod h1:Gm8eSIfQN6457haJuPaMxZw4wyP5k+ykPFlrhQDvhvw=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=

--- a/pkg/index/index.go
+++ b/pkg/index/index.go
@@ -1,0 +1,68 @@
+// index package supplies a list of sources for symbols
+package index
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/PuerkitoBio/goquery"
+)
+
+// TODO: NDX, Russel 2000, DJI, Nasdaq Composite
+// TODO: Cache results for 24h
+
+// SP500 returns the symbols on the S&P 500
+func SP500() ([]string, error) {
+	symbols := []string{}
+
+	doc, err := goquery.NewDocument("https://en.wikipedia.org/wiki/List_of_S%26P_500_companies")
+	if err != nil {
+		return nil, err
+	}
+
+	doc.Find("#constituents tr").Each(func(i int, s *goquery.Selection) {
+		sym := s.Find("td a").First().Text()
+		if len(sym) > 0 && len(sym) < 5 {
+			symbols = append(symbols, sym)
+		}
+	})
+
+	return symbols, nil
+}
+
+// SP50 returns the top-50 from the S&P 500
+func SP50() ([]string, error) {
+	symbols, err := SP500()
+	if err != nil {
+		return nil, err
+	}
+	return symbols[0:50], nil
+}
+
+func Resolve(syms []string) ([]string, error) {
+	rs := []string{}
+	for _, s := range syms {
+		if !strings.HasPrefix(s, "^") {
+			rs = append(rs, s)
+		}
+
+		switch s {
+		case "^SP500":
+			sp, err := SP500()
+			if err != nil {
+				return rs, err
+			}
+			rs = append(rs, sp...)
+		case "^SP50":
+			sp, err := SP50()
+			if err != nil {
+				return rs, err
+			}
+			rs = append(rs, sp...)
+		default:
+			return rs, fmt.Errorf("unknown index: %q", s)
+		}
+	}
+
+	return rs, nil
+}

--- a/pkg/roho/client.go
+++ b/pkg/roho/client.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"strings"
 	"time"
@@ -23,7 +22,7 @@ func cryptoURL(s string) string {
 // call retrieves from the endpoint and unmarshals resulting json into
 // the provided destination interface, which must be a pointer.
 func (c *Client) get(ctx context.Context, url string, dest interface{}) error {
-	log.Printf("url: %s", url)
+	// log.Printf("url: %s", url)
 	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 	if err != nil {
 		return err
@@ -65,7 +64,7 @@ func (c *Client) call(ctx context.Context, req *http.Request, dest interface{}) 
 		return e
 	}
 
-	log.Printf("response: %s", bs)
+	// log.Printf("response: %s", bs)
 	return json.NewDecoder(bytes.NewReader(bs)).Decode(dest)
 }
 

--- a/pkg/roho/fundamentals.go
+++ b/pkg/roho/fundamentals.go
@@ -21,10 +21,35 @@ type Fundamental struct {
 	InstrumentURL string  `json:"instrument"`
 }
 
-// Fundamentals returns fundamental data for the list of stocks provided.
-func (c *Client) Fundamentals(ctx context.Context, stocks ...string) ([]Fundamental, error) {
-	url := baseURL("fundamentals") + "?symbols=" + strings.Join(stocks, ",")
-	var r struct{ Results []Fundamental }
-	err := c.get(ctx, url, &r)
-	return r.Results, err
+// Fundamentals returns fundamental data for the list of stock symbols provided.
+func (c *Client) Fundamentals(ctx context.Context, syms ...string) ([]Fundamental, error) {
+	fs := []Fundamental{}
+
+	// Robinhood Fundamentals API only allows 100 symbols at a time
+	for _, ck := range chunkStrings(syms, 100) {
+		url := baseURL("fundamentals") + "?symbols=" + strings.Join(ck, ",")
+		var r struct{ Results []Fundamental }
+		if err := c.get(ctx, url, &r); err != nil {
+			return fs, err
+		}
+		fs = append(fs, r.Results...)
+	}
+
+	return fs, nil
+}
+
+// chunkStrings divides a slice of strings into chunks of a specified size.
+func chunkStrings(input []string, size int) [][]string {
+	var chunks [][]string
+
+	for i := 0; i < len(input); i += size {
+		end := i + size
+
+		if end > len(input) {
+			end = len(input)
+		}
+
+		chunks = append(chunks, input[i:end])
+	}
+	return chunks
 }

--- a/pkg/roho/fundamentals.go
+++ b/pkg/roho/fundamentals.go
@@ -18,7 +18,7 @@ type Fundamental struct {
 	MarketCap     float64 `json:"market_cap,string"`
 	PERatio       float64 `json:"pe_ratio,string"`
 	Description   string  `json:"description"`
-	Instrument    string  `json:"instrument"`
+	InstrumentURL string  `json:"instrument"`
 }
 
 // Fundamentals returns fundamental data for the list of stocks provided.

--- a/pkg/roho/instrument.go
+++ b/pkg/roho/instrument.go
@@ -54,7 +54,7 @@ func (c *Client) Instrument(ctx context.Context, symbol string) (Instrument, err
 	return i.Results[0], err
 }
 
-// Instrument returns Instruments for a set of stock symbols
+// Instrument returns Instruments for a set of stock symbols.
 func (c *Client) Instruments(ctx context.Context, syms []string) ([]Instrument, error) {
 	is := []Instrument{}
 	// Unlike quotes, RH has no native way to query for multiple symbols :(

--- a/pkg/roho/options.go
+++ b/pkg/roho/options.go
@@ -150,9 +150,10 @@ type MinTicks struct {
 // UnderlyingInstrument is the type that represents a link from an option back
 // to its standard financial instrument (stock).
 type UnderlyingInstrument struct {
-	ID         string `json:"id"`
-	Instrument string `json:"instrument"`
-	Quantity   int    `json:"quantity"`
+	ID            string `json:"id"`
+	InstrumentURL string `json:"instrument"`
+	InstrumentID  string `json:"instrument_id"`
+	Quantity      int    `json:"quantity"`
 }
 
 // An OptionInstrument can have a quote.

--- a/pkg/roho/options.go
+++ b/pkg/roho/options.go
@@ -48,7 +48,7 @@ func (d *Date) UnmarshalJSON(bs []byte) error {
 }
 
 // OptionChains returns options for the given instruments.
-func (c *Client) OptionChains(ctx context.Context, is ...*Instrument) ([]*OptionChain, error) {
+func (c *Client) OptionChains(ctx context.Context, is ...Instrument) ([]*OptionChain, error) {
 	s := []string{}
 	for _, inst := range is {
 		s = append(s, inst.ID)

--- a/pkg/roho/options_test.go
+++ b/pkg/roho/options_test.go
@@ -27,7 +27,7 @@ func TestMarketData(t *testing.T) {
 		t.Errorf("dial returned nil client")
 	}
 
-	i, err := c.Lookup(ctx, "SPY")
+	i, err := c.Instrument(ctx, "SPY")
 	if err != nil {
 		t.Errorf("lookup failed: %v", err)
 	}

--- a/pkg/roho/order.go
+++ b/pkg/roho/order.go
@@ -72,23 +72,22 @@ type apiOrder struct {
 // Buy buys an insstrument.
 func (c *Client) Buy(ctx context.Context, i *Instrument, o OrderOpts) (*OrderOutput, error) {
 	o.Side = Buy
-	return c.order(ctx, i, o)
+	return c.Order(ctx, i.URL, i.Symbol, o)
 }
 
 // Sell sells an instrument.
 func (c *Client) Sell(ctx context.Context, i *Instrument, o OrderOpts) (*OrderOutput, error) {
 	o.Side = Sell
-	return c.order(ctx, i, o)
+	return c.Order(ctx, i.URL, i.Symbol, o)
 }
 
-// Order places an order for a given instrument. Cancellation of the given
-// context cancels only the _http request_ and not any orders that may have
-// been created regardless of the cancellation.
-func (c *Client) order(ctx context.Context, i *Instrument, o OrderOpts) (*OrderOutput, error) {
+// Order places an order for a given instrument.
+// NOTE: Cancellation of the context cancels only the HTTP request. To cancel the order, call Order()
+func (c *Client) Order(ctx context.Context, url string, symbol string, o OrderOpts) (*OrderOutput, error) {
 	a := apiOrder{
 		Account:       c.Account.URL,
-		Instrument:    i.URL,
-		Symbol:        i.Symbol,
+		Instrument:    url,
+		Symbol:        symbol,
 		Type:          strings.ToLower(o.Type.String()),
 		TimeInForce:   strings.ToLower(o.TimeInForce.String()),
 		Quantity:      o.Quantity,
@@ -125,7 +124,7 @@ func (c *Client) order(ctx context.Context, i *Instrument, o OrderOpts) (*OrderO
 	return &out, nil
 }
 
-// OrderOutput is the response from the Order api.
+// OrderOutput is the response from the Order API.
 type OrderOutput struct {
 	Meta
 	Account                string        `json:"account"`

--- a/pkg/roho/order.go
+++ b/pkg/roho/order.go
@@ -83,7 +83,7 @@ func (c *Client) Sell(ctx context.Context, i Instrument, o OrderOpts) (*OrderOut
 }
 
 // Order places an order for a given instrument.
-// NOTE: Cancellation of the context cancels only the HTTP request. To cancel the order, call Order()
+// NOTE: Cancellation of the context cancels only the HTTP request. To cancel the order, call Order().
 func (c *Client) Order(ctx context.Context, url string, symbol string, o OrderOpts) (*OrderOutput, error) {
 	a := apiOrder{
 		Account:       c.Account.URL,

--- a/pkg/roho/order.go
+++ b/pkg/roho/order.go
@@ -70,13 +70,13 @@ type apiOrder struct {
 }
 
 // Buy buys an insstrument.
-func (c *Client) Buy(ctx context.Context, i *Instrument, o OrderOpts) (*OrderOutput, error) {
+func (c *Client) Buy(ctx context.Context, i Instrument, o OrderOpts) (*OrderOutput, error) {
 	o.Side = Buy
 	return c.Order(ctx, i.URL, i.Symbol, o)
 }
 
 // Sell sells an instrument.
-func (c *Client) Sell(ctx context.Context, i *Instrument, o OrderOpts) (*OrderOutput, error) {
+func (c *Client) Sell(ctx context.Context, i Instrument, o OrderOpts) (*OrderOutput, error) {
 	o.Side = Sell
 	return c.Order(ctx, i.URL, i.Symbol, o)
 }

--- a/pkg/roho/order.go
+++ b/pkg/roho/order.go
@@ -54,7 +54,8 @@ type OrderOpts struct {
 
 type apiOrder struct {
 	Account       string    `json:"account,omitempty"`
-	Instrument    string    `json:"instrument,omitempty"`
+	InstrumentURL string    `json:"instrument,omitempty"`
+	InstrumentID  string    `json:"instrument_id,omitempty"`
 	Symbol        string    `json:"symbol,omitempty"`
 	Type          string    `json:"type,omitempty"`
 	TimeInForce   string    `json:"time_in_force,omitempty"`
@@ -86,7 +87,7 @@ func (c *Client) Sell(ctx context.Context, i Instrument, o OrderOpts) (*OrderOut
 func (c *Client) Order(ctx context.Context, url string, symbol string, o OrderOpts) (*OrderOutput, error) {
 	a := apiOrder{
 		Account:       c.Account.URL,
-		Instrument:    url,
+		InstrumentURL: url,
 		Symbol:        symbol,
 		Type:          strings.ToLower(o.Type.String()),
 		TimeInForce:   strings.ToLower(o.TimeInForce.String()),

--- a/pkg/roho/positions.go
+++ b/pkg/roho/positions.go
@@ -9,7 +9,8 @@ type Position struct {
 	Meta
 	Account                 string  `json:"account"`
 	AverageBuyPrice         float64 `json:"average_buy_price,string"`
-	Instrument              string  `json:"instrument"`
+	InstrumentURL           string  `json:"instrument"`
+	InstrumentID            string  `json:"instrument_id"`
 	IntradayAverageBuyPrice float64 `json:"intraday_average_buy_price,string"`
 	IntradayQuantity        float64 `json:"intraday_quantity,string"`
 	Quantity                float64 `json:"quantity,string"`

--- a/pkg/roho/quote.go
+++ b/pkg/roho/quote.go
@@ -2,6 +2,7 @@ package roho
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/tstromberg/roho/pkg/times"
@@ -24,8 +25,18 @@ type Quote struct {
 	UpdatedAt                   string  `json:"updated_at"`
 }
 
-// Quote returns the latest stock quotes for the list of stocks provided.
-func (c *Client) Quote(ctx context.Context, symbols ...string) ([]Quote, error) {
+// Quote returns the latest stock quote for a symbol
+func (c *Client) Quote(ctx context.Context, symbol string) (Quote, error) {
+	qs, err := c.Quotes(ctx, []string{symbol})
+	return qs[0], err
+}
+
+// Quote returns the latest stock quotes for the symbols provided.
+func (c *Client) Quotes(ctx context.Context, symbols []string) ([]Quote, error) {
+	if len(symbols) == 0 {
+		return nil, fmt.Errorf("0 symbols provided")
+	}
+
 	url := baseURL("quotes") + "?symbols=" + strings.Join(symbols, ",")
 	var r struct{ Results []Quote }
 	err := c.get(ctx, url, &r)

--- a/pkg/roho/quote.go
+++ b/pkg/roho/quote.go
@@ -27,7 +27,7 @@ type Quote struct {
 	InstrumentID                string  `json:"instrument_id"`
 }
 
-// Quote returns the latest stock quote for a symbol
+// Quote returns the latest stock quote for a symbol.
 func (c *Client) Quote(ctx context.Context, symbol string) (Quote, error) {
 	qs, err := c.Quotes(ctx, []string{symbol})
 	return qs[0], err

--- a/pkg/roho/quote.go
+++ b/pkg/roho/quote.go
@@ -25,8 +25,8 @@ type Quote struct {
 }
 
 // GetQuote returns all the latest stock quotes for the list of stocks provided.
-func (c *Client) Quote(ctx context.Context, stocks ...string) ([]Quote, error) {
-	url := baseURL("quotes") + "?symbols=" + strings.Join(stocks, ",")
+func (c *Client) Quote(ctx context.Context, symbols ...string) ([]Quote, error) {
+	url := baseURL("quotes") + "?symbols=" + strings.Join(symbols, ",")
 	var r struct{ Results []Quote }
 	err := c.get(ctx, url, &r)
 	return r.Results, err

--- a/pkg/roho/quote.go
+++ b/pkg/roho/quote.go
@@ -23,6 +23,8 @@ type Quote struct {
 	Symbol                      string  `json:"symbol"`
 	TradingHalted               bool    `json:"trading_halted"`
 	UpdatedAt                   string  `json:"updated_at"`
+	InstrumentURL               string  `json:"instrument"`
+	InstrumentID                string  `json:"instrument_id"`
 }
 
 // Quote returns the latest stock quote for a symbol

--- a/pkg/roho/roho.go
+++ b/pkg/roho/roho.go
@@ -3,7 +3,6 @@ package roho
 import (
 	"context"
 	"fmt"
-	"log"
 	"net/http"
 	"os"
 
@@ -32,7 +31,6 @@ func New(ctx context.Context, c *Config) (*Client, error) {
 		return nil, fmt.Errorf("token: %w", err)
 	}
 
-	log.Printf("Logging into Robinhood as %s ...", user)
 	return Dial(ctx, oauth2.StaticTokenSource(token))
 }
 
@@ -57,7 +55,6 @@ func Dial(ctx context.Context, s oauth2.TokenSource) (*Client, error) {
 		return nil, fmt.Errorf("accounts: %w", err)
 	}
 
-	log.Printf("Found %d accounts", len(a))
 	if len(a) > 0 {
 		c.Account = &a[0]
 	}
@@ -67,7 +64,6 @@ func Dial(ctx context.Context, s oauth2.TokenSource) (*Client, error) {
 		return nil, fmt.Errorf("crypto accounts: %w", err)
 	}
 
-	log.Printf("Found %d crypto accounts", len(ca))
 	if len(ca) > 0 {
 		c.CryptoAccount = &ca[0]
 	}

--- a/pkg/roho/watchlists.go
+++ b/pkg/roho/watchlists.go
@@ -50,8 +50,8 @@ func (w *Watchlist) Instruments(ctx context.Context) ([]Instrument, error) {
 		// shadow for safe closure access
 		i := i
 		eg.Go(func() error {
-			inst, err := w.c.Lookup(ctx, r.Results[i].Instrument)
-			insts[i] = inst
+			inst, err := w.c.Instrument(ctx, r.Results[i].Instrument)
+			insts[i] = &inst
 			return err
 		})
 	}

--- a/pkg/strategy/data.go
+++ b/pkg/strategy/data.go
@@ -9,7 +9,7 @@ import (
 	"github.com/tstromberg/roho/pkg/roho"
 )
 
-// LiveData gathers combined live stock information
+// LiveData gathers combined live stock information.
 func LiveData(ctx context.Context, r *roho.Client, syms []string) (map[string]*CombinedStock, error) {
 	cs := map[string]*CombinedStock{}
 
@@ -19,6 +19,8 @@ func LiveData(ctx context.Context, r *roho.Client, syms []string) (map[string]*C
 	}
 
 	for _, p := range ps {
+		// avoid implicit memory aliasing within a for loop
+		p := p
 		log.Printf("position: %s", p.InstrumentURL)
 		cs[p.InstrumentURL] = &CombinedStock{Position: &p}
 
@@ -36,6 +38,8 @@ func LiveData(ctx context.Context, r *roho.Client, syms []string) (map[string]*C
 	}
 
 	for _, q := range qs {
+		// avoid implicit memory aliasing within a for loop
+		q := q
 		_, ok := cs[q.InstrumentURL]
 		if !ok {
 			cs[q.InstrumentURL] = &CombinedStock{}
@@ -49,14 +53,16 @@ func LiveData(ctx context.Context, r *roho.Client, syms []string) (map[string]*C
 	}
 
 	for _, f := range fs {
+		// avoid implicit memory aliasing within a for loop
+		f := f
 		cs[f.InstrumentURL].Fundamentals = &f
 	}
 
 	return cs, nil
 }
 
-// HistoricalData simulates data at a particular point in the past - NOT YET IMPLEMENTED
-func HistoricalData(ctx context.Context, r *roho.Client, syms []string, t time.Time) (map[string]*CombinedStock, error) {
+// HistoricalData simulates data at a particular point in the past - NOT YET IMPLEMENTED.
+func HistoricalData(_ context.Context, _ *roho.Client, _ []string, _ time.Time) (map[string]*CombinedStock, error) {
 	cs := map[string]*CombinedStock{}
 	return cs, fmt.Errorf("HistoricalData is NOT YET IMPLEMENTED")
 }

--- a/pkg/strategy/data.go
+++ b/pkg/strategy/data.go
@@ -1,0 +1,62 @@
+package strategy
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/tstromberg/roho/pkg/roho"
+)
+
+// LiveData gathers combined live stock information
+func LiveData(ctx context.Context, r *roho.Client, syms []string) (map[string]*CombinedStock, error) {
+	cs := map[string]*CombinedStock{}
+
+	ps, err := r.Positions(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("positions: %w", err)
+	}
+
+	for _, p := range ps {
+		log.Printf("position: %s", p.InstrumentURL)
+		cs[p.InstrumentURL] = &CombinedStock{Position: &p}
+
+		f, err := r.InstrumentFromURL(ctx, p.InstrumentURL)
+		if err != nil {
+			return cs, fmt.Errorf("instrument from %q: %w", p.InstrumentURL, err)
+		}
+
+		syms = append(syms, f.Symbol)
+	}
+
+	qs, err := r.Quotes(ctx, syms)
+	if err != nil {
+		return nil, fmt.Errorf("quote: %w", err)
+	}
+
+	for _, q := range qs {
+		_, ok := cs[q.InstrumentURL]
+		if !ok {
+			cs[q.InstrumentURL] = &CombinedStock{}
+		}
+		cs[q.InstrumentURL].Quote = &q
+	}
+
+	fs, err := r.Fundamentals(ctx, syms...)
+	if err != nil {
+		return nil, fmt.Errorf("fundamentals: %w", err)
+	}
+
+	for _, f := range fs {
+		cs[f.InstrumentURL].Fundamentals = &f
+	}
+
+	return cs, nil
+}
+
+// HistoricalData simulates data at a particular point in the past - NOT YET IMPLEMENTED
+func HistoricalData(ctx context.Context, r *roho.Client, syms []string, t time.Time) (map[string]*CombinedStock, error) {
+	cs := map[string]*CombinedStock{}
+	return cs, fmt.Errorf("HistoricalData is NOT YET IMPLEMENTED")
+}

--- a/pkg/strategy/hilo.go
+++ b/pkg/strategy/hilo.go
@@ -1,0 +1,60 @@
+package strategy
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/tstromberg/roho/pkg/roho"
+)
+
+// HiLoStrategy is a demonstration strategy to buy/sell stocks when near their 52-week hi/low averages.
+type HiLoStrategy struct {
+	c Config
+}
+
+func (cr *HiLoStrategy) String() string {
+	return "HiLo"
+}
+
+func (cr *HiLoStrategy) Trades(_ context.Context, cs map[string]*CombinedStock) ([]Trade, error) {
+	ts := []Trade{}
+
+	for url, s := range cs {
+		p := s.Position
+
+		// We don't already own this stock
+		if p == nil {
+			ratio := s.Quote.BidPrice / s.Fundamentals.Low52Weeks
+			if ratio < 1.01 {
+				ts = append(ts, Trade{
+					InstrumentURL: url,
+					Symbol:        s.Quote.Symbol,
+					Order:         roho.OrderOpts{Price: s.Quote.AskPrice, Quantity: 1, Side: roho.Buy},
+					Reason:        fmt.Sprintf("Near 52-week low of %.2f", s.Fundamentals.Low52Weeks),
+				})
+			}
+			continue
+		}
+
+		ratio := s.Quote.BidPrice / s.Fundamentals.High52Weeks
+		log.Printf("%s: ratio between buy %.2f and high %.2f is %.2f", s.Quote.Symbol, s.Quote.BidPrice, s.Fundamentals.High52Weeks, ratio)
+		if ratio > 0.99 {
+			// Only sell if we make a profit
+			if p.AverageBuyPrice < s.Quote.BidPrice {
+				log.Printf("would sell %s for %.2f but we paid %.2f for it", s.Quote.Symbol, s.Quote.BidPrice, p.AverageBuyPrice)
+				continue
+			}
+
+			ts = append(ts, Trade{
+				InstrumentURL: url,
+				Symbol:        s.Quote.Symbol,
+				Order:         roho.OrderOpts{Price: p.AverageBuyPrice, Quantity: uint64(p.Quantity), Side: roho.Sell},
+				Reason:        fmt.Sprintf("Near 52-week high of %.2f", s.Fundamentals.High52Weeks),
+			})
+			continue
+		}
+	}
+
+	return ts, nil
+}

--- a/pkg/strategy/lucky_sevens.go
+++ b/pkg/strategy/lucky_sevens.go
@@ -1,0 +1,59 @@
+package strategy
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/tstromberg/roho/pkg/roho"
+)
+
+// LuckySevens is a simple strategy to sell stocks at 7.77, and buy at 8.88.
+type LuckySevens struct {
+	c Config
+}
+
+func (cr *LuckySevens) String() string {
+	return "Lucky Sevens"
+}
+
+func (cr *LuckySevens) Simulate(ctx context.Context, _ time.Time) error {
+	return nil
+}
+
+func (cr *LuckySevens) Symbols(ctx context.Context) ([]string, error) {
+	return []string{"SPY"}, nil
+}
+
+func (cr *LuckySevens) Trades(ctx context.Context, symbols []string) ([]Trade, error) {
+	r := cr.c.Client
+	ts := []Trade{}
+	qs, err := r.Quote(ctx, symbols...)
+	if err != nil {
+		return ts, fmt.Errorf("quote for %q: %w", symbols, err)
+	}
+
+	for _, q := range qs {
+		ask := fmt.Sprintf("%.2f", q.AskPrice)
+		bid := fmt.Sprintf("%.2f", q.BidPrice)
+		log.Printf("%q ask=%s bid=%s", q.Symbol, ask, bid)
+
+		switch {
+		case ask == "7.77" || ask == "77.70":
+			i, err := r.Lookup(ctx, q.Symbol)
+			if err != nil {
+				return ts, fmt.Errorf("lookup for %q: %w", q.Symbol, err)
+			}
+			ts = append(ts, Trade{Instrument: i, Order: roho.OrderOpts{Price: q.AskPrice, Quantity: 7, Side: roho.Buy}})
+		case bid == "8.88" || ask == "88.80":
+			i, err := r.Lookup(ctx, q.Symbol)
+			if err != nil {
+				return ts, fmt.Errorf("lookup for %q: %w", q.Symbol, err)
+			}
+			ts = append(ts, Trade{Instrument: i, Order: roho.OrderOpts{Price: q.BidPrice, Quantity: 7, Side: roho.Sell}})
+		}
+	}
+
+	return ts, nil
+}

--- a/pkg/strategy/lucky_sevens.go
+++ b/pkg/strategy/lucky_sevens.go
@@ -3,57 +3,46 @@ package strategy
 import (
 	"context"
 	"fmt"
-	"log"
+	"regexp"
 	"time"
 
 	"github.com/tstromberg/roho/pkg/roho"
 )
 
-// LuckySevens is a simple strategy to sell stocks at 7.77, and buy at 8.88.
-type LuckySevens struct {
+var (
+	sevenRe = regexp.MustCompile(`^[7\.]+[70]$`)
+	eightRe = regexp.MustCompile(`^[8\.]+[80]$`)
+)
+
+// LuckySevens is a simple strategy to buy stocks at 7.77 and sell them at 8.88
+type LuckySevensStrategy struct {
 	c Config
 }
 
-func (cr *LuckySevens) String() string {
+func (cr *LuckySevensStrategy) String() string {
 	return "Lucky Sevens"
 }
 
-func (cr *LuckySevens) Simulate(ctx context.Context, _ time.Time) error {
-	return nil
-}
-
-func (cr *LuckySevens) Symbols(ctx context.Context) ([]string, error) {
-	return []string{"SPY"}, nil
-}
-
-func (cr *LuckySevens) Trades(ctx context.Context, symbols []string) ([]Trade, error) {
-	r := cr.c.Client
+func (cr *LuckySevensStrategy) Trades(ctx context.Context, ps []roho.Position, qs []roho.Quote) ([]Trade, error) {
 	ts := []Trade{}
-	qs, err := r.Quote(ctx, symbols...)
-	if err != nil {
-		return ts, fmt.Errorf("quote for %q: %w", symbols, err)
+
+	for _, p := range ps {
+		bid := fmt.Sprintf("%.2f", p.AverageBuyPrice)
+		if eightRe.MatchString(bid) {
+			ts = append(ts, Trade{InstrumentURL: p.Instrument, Order: roho.OrderOpts{Price: p.AverageBuyPrice, Quantity: uint64(p.Quantity), Side: roho.Sell}})
+		}
 	}
 
 	for _, q := range qs {
 		ask := fmt.Sprintf("%.2f", q.AskPrice)
-		bid := fmt.Sprintf("%.2f", q.BidPrice)
-		log.Printf("%q ask=%s bid=%s", q.Symbol, ask, bid)
-
-		switch {
-		case ask == "7.77" || ask == "77.70":
-			i, err := r.Lookup(ctx, q.Symbol)
-			if err != nil {
-				return ts, fmt.Errorf("lookup for %q: %w", q.Symbol, err)
-			}
-			ts = append(ts, Trade{Instrument: i, Order: roho.OrderOpts{Price: q.AskPrice, Quantity: 7, Side: roho.Buy}})
-		case bid == "8.88" || ask == "88.80":
-			i, err := r.Lookup(ctx, q.Symbol)
-			if err != nil {
-				return ts, fmt.Errorf("lookup for %q: %w", q.Symbol, err)
-			}
-			ts = append(ts, Trade{Instrument: i, Order: roho.OrderOpts{Price: q.BidPrice, Quantity: 7, Side: roho.Sell}})
+		if sevenRe.MatchString(ask) {
+			ts = append(ts, Trade{Symbol: q.Symbol, Order: roho.OrderOpts{Price: q.AskPrice, Quantity: 7, Side: roho.Buy}})
 		}
 	}
 
 	return ts, nil
+}
+
+func (cr *LuckySevensStrategy) SetTime(ctx context.Context, _ time.Time) error {
+	return nil
 }

--- a/pkg/strategy/lucky_sevens.go
+++ b/pkg/strategy/lucky_sevens.go
@@ -13,7 +13,7 @@ var (
 	eightRe = regexp.MustCompile(`^[8\.]+[80]$`)
 )
 
-// LuckySevens is a simple strategy to buy stocks at 7.77 and sell them at 8.88
+// LuckySevensStrategy is a demonstration strategy to buy stocks at 7.77 and sell them at 8.88.
 type LuckySevensStrategy struct {
 	c Config
 }
@@ -22,7 +22,7 @@ func (cr *LuckySevensStrategy) String() string {
 	return "Lucky Sevens"
 }
 
-func (cr *LuckySevensStrategy) Trades(ctx context.Context, cs map[string]*CombinedStock) ([]Trade, error) {
+func (cr *LuckySevensStrategy) Trades(_ context.Context, cs map[string]*CombinedStock) ([]Trade, error) {
 	ts := []Trade{}
 
 	for url, s := range cs {

--- a/pkg/strategy/random.go
+++ b/pkg/strategy/random.go
@@ -1,0 +1,58 @@
+package strategy
+
+import (
+	"context"
+	"crypto/rand"
+	"fmt"
+	"math/big"
+	"time"
+
+	"github.com/tstromberg/roho/pkg/roho"
+)
+
+var (
+	myLuckyNumber = int64(4)
+)
+
+// Randob is a simple strategy to buy stocks at 7.77 and sell them at 8.88
+type RandomStrategy struct {
+	c Config
+}
+
+func (cr *RandomStrategy) String() string {
+	return "Random"
+}
+
+func (cr *RandomStrategy) Trades(ctx context.Context, ps []roho.Position, qs []roho.Quote) ([]Trade, error) {
+	maxRand := int64(len(ps)+len(qs)) * myLuckyNumber
+	ts := []Trade{}
+
+	for _, p := range ps {
+		nb, err := rand.Int(rand.Reader, big.NewInt(maxRand))
+		if err != nil {
+			return ts, fmt.Errorf("rand int: %w", err)
+		}
+		if nb.Int64() != myLuckyNumber {
+			continue
+		}
+		ts = append(ts, Trade{InstrumentURL: p.Instrument, Order: roho.OrderOpts{Price: p.AverageBuyPrice, Quantity: uint64(p.Quantity), Side: roho.Sell}})
+
+	}
+
+	for _, q := range qs {
+		nb, err := rand.Int(rand.Reader, big.NewInt(maxRand))
+		if err != nil {
+			return ts, fmt.Errorf("rand int: %w", err)
+		}
+		if nb.Int64() != myLuckyNumber {
+			continue
+		}
+		ts = append(ts, Trade{Symbol: q.Symbol, Order: roho.OrderOpts{Price: q.AskPrice, Quantity: 7, Side: roho.Buy}})
+	}
+
+	return ts, nil
+}
+
+func (cr *RandomStrategy) SetTime(ctx context.Context, _ time.Time) error {
+	return nil
+}

--- a/pkg/strategy/random.go
+++ b/pkg/strategy/random.go
@@ -5,14 +5,13 @@ import (
 	"crypto/rand"
 	"fmt"
 	"math/big"
-	"time"
 
 	"github.com/tstromberg/roho/pkg/roho"
 )
 
 var myLuckyNumber = int64(4)
 
-// Randob is a simple strategy to buy stocks at 7.77 and sell them at 8.88
+// RandomStrategy is a demonstration strategy to buy/sell stocks at random.
 type RandomStrategy struct {
 	c Config
 }
@@ -21,7 +20,7 @@ func (cr *RandomStrategy) String() string {
 	return "Random"
 }
 
-func (cr *RandomStrategy) Trades(ctx context.Context, cs map[string]*CombinedStock) ([]Trade, error) {
+func (cr *RandomStrategy) Trades(_ context.Context, cs map[string]*CombinedStock) ([]Trade, error) {
 	maxRand := int64(len(cs)) * myLuckyNumber
 	ts := []Trade{}
 
@@ -38,7 +37,6 @@ func (cr *RandomStrategy) Trades(ctx context.Context, cs map[string]*CombinedSto
 			continue
 		}
 		ts = append(ts, Trade{Symbol: sym, Order: roho.OrderOpts{Price: c.Position.AverageBuyPrice, Quantity: uint64(c.Position.Quantity), Side: roho.Sell}})
-
 	}
 
 	for sym, c := range cs {
@@ -53,8 +51,4 @@ func (cr *RandomStrategy) Trades(ctx context.Context, cs map[string]*CombinedSto
 	}
 
 	return ts, nil
-}
-
-func (cr *RandomStrategy) SetTime(ctx context.Context, _ time.Time) error {
-	return nil
 }

--- a/pkg/strategy/strategy.go
+++ b/pkg/strategy/strategy.go
@@ -8,17 +8,23 @@ import (
 	"github.com/tstromberg/roho/pkg/roho"
 )
 
+var (
+	LuckySevens = "lucky-sevens"
+	Random      = "random"
+	strategies  = []string{LuckySevens, Random}
+)
+
 type Trade struct {
-	Instrument *roho.Instrument
-	Order      roho.OrderOpts
-	Reason     string
+	Symbol        string
+	InstrumentURL string
+	Order         roho.OrderOpts
+	Reason        string
 }
 
-// Commander is a common interface for executing strategies
-type Commander interface {
-	Trades(context.Context, []string) ([]Trade, error)
-	Symbols(context.Context) ([]string, error)
-	Simulate(context.Context, time.Time) error
+// Strategy is an interface for executing stock strategies
+type Strategy interface {
+	Trades(ctx context.Context, ps []roho.Position, qs []roho.Quote) ([]Trade, error)
+	SetTime(ctx context.Context, t time.Time) error
 	String() string
 }
 
@@ -29,12 +35,20 @@ type Config struct {
 }
 
 // New returns a new strategy manager
-func New(ctx context.Context, c Config) (Commander, error) {
+func New(ctx context.Context, c Config) (Strategy, error) {
 	switch c.Kind {
-	case "lucky-sevens":
-		l := &LuckySevens{c: c}
+	case LuckySevens:
+		l := &LuckySevensStrategy{c: c}
+		return l, nil
+	case Random:
+		l := &RandomStrategy{c: c}
 		return l, nil
 	default:
 		return nil, fmt.Errorf("no strategy named %q exists", c.Kind)
 	}
+}
+
+// List returns a list of strategies
+func List() []string {
+	return strategies
 }

--- a/pkg/strategy/strategy.go
+++ b/pkg/strategy/strategy.go
@@ -1,0 +1,40 @@
+package strategy
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/tstromberg/roho/pkg/roho"
+)
+
+type Trade struct {
+	Instrument *roho.Instrument
+	Order      roho.OrderOpts
+	Reason     string
+}
+
+// Commander is a common interface for executing strategies
+type Commander interface {
+	Trades(context.Context, []string) ([]Trade, error)
+	Symbols(context.Context) ([]string, error)
+	Simulate(context.Context, time.Time) error
+	String() string
+}
+
+type Config struct {
+	Client   *roho.Client
+	Kind     string
+	Holdings []string
+}
+
+// New returns a new strategy manager
+func New(ctx context.Context, c Config) (Commander, error) {
+	switch c.Kind {
+	case "lucky-sevens":
+		l := &LuckySevens{c: c}
+		return l, nil
+	default:
+		return nil, fmt.Errorf("no strategy named %q exists", c.Kind)
+	}
+}

--- a/pkg/strategy/strategy.go
+++ b/pkg/strategy/strategy.go
@@ -10,7 +10,8 @@ import (
 var (
 	LuckySevens = "lucky-sevens"
 	Random      = "random"
-	strategies  = []string{LuckySevens, Random}
+	HiLo        = "hilo"
+	strategies  = []string{LuckySevens, Random, HiLo}
 )
 
 type Trade struct {
@@ -27,7 +28,7 @@ type CombinedStock struct {
 	Historical   *roho.Historical
 }
 
-// Strategy is an interface for executing stock strategies
+// Strategy is an interface for executing stock strategies.
 type Strategy interface {
 	Trades(ctx context.Context, cs map[string]*CombinedStock) ([]Trade, error)
 	String() string
@@ -39,8 +40,8 @@ type Config struct {
 	Holdings []string
 }
 
-// New returns a new strategy manager
-func New(ctx context.Context, c Config) (Strategy, error) {
+// New returns a new strategy manager.
+func New(c Config) (Strategy, error) {
 	switch c.Kind {
 	case LuckySevens:
 		l := &LuckySevensStrategy{c: c}
@@ -48,12 +49,15 @@ func New(ctx context.Context, c Config) (Strategy, error) {
 	case Random:
 		l := &RandomStrategy{c: c}
 		return l, nil
+	case HiLo:
+		l := &HiLoStrategy{c: c}
+		return l, nil
 	default:
 		return nil, fmt.Errorf("no strategy named %q exists", c.Kind)
 	}
 }
 
-// List returns a list of strategies
+// List returns a list of strategies.
 func List() []string {
 	return strategies
 }

--- a/pkg/strategy/strategy.go
+++ b/pkg/strategy/strategy.go
@@ -3,7 +3,6 @@ package strategy
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/tstromberg/roho/pkg/roho"
 )
@@ -21,10 +20,16 @@ type Trade struct {
 	Reason        string
 }
 
+type CombinedStock struct {
+	Quote        *roho.Quote
+	Fundamentals *roho.Fundamental
+	Position     *roho.Position
+	Historical   *roho.Historical
+}
+
 // Strategy is an interface for executing stock strategies
 type Strategy interface {
-	Trades(ctx context.Context, ps []roho.Position, qs []roho.Quote) ([]Trade, error)
-	SetTime(ctx context.Context, t time.Time) error
+	Trades(ctx context.Context, cs map[string]*CombinedStock) ([]Trade, error)
 	String() string
 }
 


### PR DESCRIPTION
The basic idea here is to define a common interface for basic trading strategies, and provide a functional executor (matador) for them. This PR contains 3 demonstration strategies: random, hilo, and lucky-sevens. None of these examples are appropriate as a real trading strategy, but do demonstrate how to write one.

Notably, this PR does not yet introduce back-testing, but the plumbing is there for it.