### PR TITLE
Add bounce strategy

### DIFF
--- a/cmd/example/example.go
+++ b/cmd/example/example.go
@@ -51,11 +51,11 @@ func main() {
 	}
 	log.Printf("SPY opening price was $%.2f (52 week high: $%.2f)", fs[0].Open, fs[0].High52Weeks)
 
-	hs, err := r.Historicals(ctx, "day", "week", sym)
+	hs, err := r.Historical(ctx, roho.TenMinute, roho.Day, sym)
 	if err != nil {
 		log.Fatalf("get historicals failed: %v", err)
 	}
-	for _, r := range hs[0].Records {
+	for _, r := range hs.Records {
 		log.Printf("  %s: opened at %.2f, closed at %.2f", r.BeginsAt, r.OpenPrice, r.ClosePrice)
 	}
 

--- a/cmd/matador/matador.go
+++ b/cmd/matador/matador.go
@@ -118,7 +118,7 @@ func loop(ctx context.Context, r *roho.Client, st strategy.Strategy, syms []stri
 		if counter.Polls > 1 {
 			klog.Infof("%d buys, %d sells. Sleeping for %s...", counter.TotalBuys, counter.TotalSales, maxSleep)
 			time.Sleep(maxSleep)
-			klog.Infof("Updating data for %s symbols ...", len(combined))
+			klog.Infof("Updating data for %d symbols ...", len(combined))
 			combined, err = strategy.UpdateData(ctx, r, combined)
 			if err != nil {
 				klog.Errorf("failed to update data: %v", err)

--- a/pkg/roho/historicals.go
+++ b/pkg/roho/historicals.go
@@ -26,10 +26,36 @@ type HistoricalRecord struct {
 	Interpolated bool      `json:"interpolated"`
 }
 
-// Historicals returns historical data for the list of stocks provided.
-func (c *Client) Historicals(ctx context.Context, interval string, span string, stocks ...string) ([]Historical, error) {
-	url := fmt.Sprintf("%s?interval=%s&span=%s&symbols=%s", baseURL("quotes/historicals"), interval, span, strings.Join(stocks, ","))
+const (
+	// Valid interval values.
+	FiveMinute   = "5minute"
+	TenMinute    = "10minute"
+	ThirtyMinute = "30minute"
+	Hour         = "hour"
+
+	// Valid for both intervals and spans.
+	Day  = "day"
+	Week = "week"
+
+	// Valid span values.
+	Month    = "month"
+	Year     = "year"
+	FiveYear = "5year"
+)
+
+// Historicals returns historical data for the list of stocks provided. See the interval/span constants for hints.
+func (c *Client) Historicals(ctx context.Context, interval string, span string, symbols []string) ([]Historical, error) {
+	url := fmt.Sprintf("%s?interval=%s&span=%s&symbols=%s", baseURL("quotes/historicals"), interval, span, strings.Join(symbols, ","))
 	var r struct{ Results []Historical }
 	err := c.get(ctx, url, &r)
 	return r.Results, err
+}
+
+// Historicals returns historical data for the list of stocks provided. See the interval/span constants for hints.
+func (c *Client) Historical(ctx context.Context, interval string, span string, symbol string) (Historical, error) {
+	hs, err := c.Historicals(ctx, interval, span, []string{symbol})
+	if err != nil {
+		return Historical{}, err
+	}
+	return hs[0], nil
 }

--- a/pkg/strategy/bounce.go
+++ b/pkg/strategy/bounce.go
@@ -1,0 +1,194 @@
+package strategy
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/tstromberg/roho/pkg/roho"
+	"k8s.io/klog/v2"
+)
+
+// BounceStrategy is a demonstration strategy to buy/sell stocks when near their 52-week hi/low averages.
+type BounceStrategy struct {
+	c Config
+}
+
+func (cr *BounceStrategy) String() string {
+	return "Bounce"
+}
+
+func (cr *BounceStrategy) Trades(ctx context.Context, cs []*CombinedStock) ([]Trade, error) {
+	ts := []Trade{}
+
+	for _, s := range cs {
+		if s.Position == nil {
+			t := cr.determineBuy(ctx, s)
+			if t != nil {
+				ts = append(ts, *t)
+			}
+			continue
+		}
+
+		t := cr.determineSell(ctx, s)
+		if t != nil {
+			ts = append(ts, *t)
+		}
+	}
+
+	return ts, nil
+}
+
+func upward(fs []float64) (bool, float64) {
+	upward := true
+
+	for i, f := range fs {
+		if i == 0 {
+			continue
+		}
+		if f < fs[0] {
+			upward = false
+		}
+	}
+
+	//	klog.Infof("upward values=%v, trend is %.2f", fs, percentDiff(fs[0], fs[len(fs)-1]))
+	return upward, percentDiff(fs[0], fs[len(fs)-1])
+}
+
+const (
+	minTrend       = 7
+	bounceNearness = 1.0
+)
+
+func downward(fs []float64) (bool, float64) {
+	downward := true
+
+	for i, f := range fs {
+		if i == 0 {
+			continue
+		}
+		if f > fs[0] {
+			downward = false
+		}
+	}
+
+	//	klog.Infof("downward values=%v, trend is %.2f", fs, percentDiff(fs[0], fs[len(fs)-1]))
+	return downward, percentDiff(fs[0], fs[len(fs)-1])
+}
+
+func priceTrend(rs []roho.HistoricalRecord) []float64 {
+	prices := []float64{}
+	for _, r := range rs {
+		prices = append(prices, r.OpenPrice)
+		prices = append(prices, r.ClosePrice)
+	}
+	return prices
+}
+
+func (cr *BounceStrategy) determineBuy(ctx context.Context, s *CombinedStock) *Trade {
+	perc := percentDiff(s.Fundamentals.Low52Weeks, s.Quote.AskPrice)
+	if perc > bounceNearness {
+		return nil
+	}
+
+	klog.Infof("%s: ask price of %.2f is %.2f%% away from 52-week low of %.2f", s.Instrument.Symbol, s.Quote.AskPrice, perc, s.Fundamentals.Low52Weeks)
+
+	var hs roho.Historical
+	var err error
+	if s.Historical != nil {
+		hs = *s.Historical
+	} else {
+		hs, err = cr.c.Client.Historical(ctx, "5minute", "day", s.Instrument.Symbol)
+		if err != nil {
+			klog.Errorf("get historicals failed: %v", err)
+			return nil
+		}
+	}
+
+	prices := append(priceTrend(hs.Records), s.Quote.AskPrice)
+
+	if len(prices) < minTrend {
+		klog.Warningf("%s: not enough historical data: %v", s.Instrument.Symbol, prices)
+		return nil
+	}
+
+	recent := lastFloats(prices, minTrend)
+
+	ok, bounce := upward(recent)
+	if ok && bounce > 0.01 {
+		klog.Infof("%s: buy now: upward=%v, bounce=%.2f: %v", s.Instrument.Symbol, ok, bounce, recent)
+		return &Trade{
+			Instrument: s.Instrument,
+			Order:      roho.OrderOpts{Price: s.Quote.AskPrice, Quantity: 1, Side: roho.Buy},
+			Reason:     fmt.Sprintf("%.1f%% away from 52wk low of %.2f, %.2f%% bounce", perc, s.Fundamentals.Low52Weeks, bounce),
+		}
+	}
+
+	klog.Infof("%s: wait to buy: upward=%v, bounce=%.2f: %v", s.Instrument.Symbol, ok, bounce, recent)
+	return nil
+}
+
+func lastFloats(nums []float64, size int) []float64 {
+	if len(nums) <= size {
+		return nums
+	}
+	return nums[len(nums)-size:]
+}
+
+func (cr *BounceStrategy) determineSell(ctx context.Context, s *CombinedStock) *Trade {
+	p := s.Position
+
+	ratio := s.Quote.BidPrice / s.Fundamentals.High52Weeks
+	perc := 100 - (ratio * 100)
+
+	if perc < 2 {
+		klog.Infof("%s: bid price of %.2f is %.2f%% away from 52-week high of %.2f", s.Instrument.Symbol, s.Quote.BidPrice, perc, s.Fundamentals.High52Weeks)
+	}
+
+	if perc < 0 {
+		klog.Warningf("%s sell perc=%.2f - bid price is above 52 weeks?", s.Instrument.Symbol, perc)
+		return nil
+	}
+
+	if perc > bounceNearness {
+		return nil
+	}
+
+	if p.AverageBuyPrice > s.Quote.BidPrice {
+		klog.Infof("would sell %s for %.2f but we paid %.2f for it", s.Instrument.Symbol, s.Quote.BidPrice, p.AverageBuyPrice)
+		return nil
+	}
+
+	var hs roho.Historical
+	var err error
+	if s.Historical != nil {
+		hs = *s.Historical
+	} else {
+		hs, err = cr.c.Client.Historical(ctx, "5minute", "day", s.Instrument.Symbol)
+		if err != nil {
+			klog.Errorf("get historicals failed: %v", err)
+			return nil
+		}
+	}
+
+	prices := append(priceTrend(hs.Records), s.Quote.BidPrice)
+	if len(prices) < minTrend {
+		klog.Warningf("%s: not enough historical data: %v", s.Instrument.Symbol, prices)
+		return nil
+	}
+
+	recent := lastFloats(prices, minTrend)
+	ok, bounce := downward(recent)
+
+	if ok && bounce < -0.01 {
+		klog.Infof("%s: sell now: upward=%v, bounce=%.2f: %v", s.Instrument.Symbol, ok, bounce, recent)
+
+		return &Trade{
+			Instrument: s.Instrument,
+			Order:      roho.OrderOpts{Price: s.Quote.BidPrice, Quantity: uint64(p.Quantity), Side: roho.Sell},
+			Reason:     fmt.Sprintf("%.1f%% away from 52-week high of %.2f, %.2f%% bounce", perc, s.Fundamentals.High52Weeks, bounce),
+		}
+	}
+
+	klog.Infof("%s: wait to sell: downward=%v, bounce=%.2f: %v", s.Instrument.Symbol, ok, bounce, recent)
+	return nil
+}

--- a/pkg/strategy/bounce.go
+++ b/pkg/strategy/bounce.go
@@ -8,7 +8,7 @@ import (
 	"k8s.io/klog/v2"
 )
 
-// BounceStrategy is a demonstration strategy to buy/sell stocks when near their 52-week hi/low averages.
+// BounceStrategy is a demonstration strategy to buy/sell stocks when they change direction near their 52-week hi/low
 type BounceStrategy struct {
 	c Config
 }

--- a/pkg/strategy/bounce.go
+++ b/pkg/strategy/bounce.go
@@ -8,7 +8,7 @@ import (
 	"k8s.io/klog/v2"
 )
 
-// BounceStrategy is a demonstration strategy to buy/sell stocks when they change direction near their 52-week hi/low
+// BounceStrategy is a demonstration strategy to buy/sell stocks when they change direction near their 52-week hi/low.
 type BounceStrategy struct {
 	c Config
 }

--- a/pkg/strategy/bounce_test.go
+++ b/pkg/strategy/bounce_test.go
@@ -1,0 +1,147 @@
+package strategy
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/tstromberg/roho/pkg/roho"
+)
+
+func TestBounce(t *testing.T) {
+	s, err := New(Config{Kind: Bounce})
+	if err != nil {
+		t.Fatalf("New() returned error: %v", err)
+	}
+
+	cs := []*CombinedStock{
+		{
+			Instrument:   &roho.Instrument{Symbol: "hold-stalled-position"},
+			Position:     &roho.Position{Quantity: 3, AverageBuyPrice: 6.00},
+			Quote:        &roho.Quote{BidPrice: 8.88},
+			Fundamentals: &roho.Fundamental{High52Weeks: 8.88},
+			Historical: &roho.Historical{
+				Records: []roho.HistoricalRecord{
+					{OpenPrice: 8.88, ClosePrice: 8.88, LowPrice: 8.88, HighPrice: 8.88},
+					{OpenPrice: 8.88, ClosePrice: 8.88, LowPrice: 8.88, HighPrice: 8.88},
+					{OpenPrice: 8.88, ClosePrice: 8.88, LowPrice: 8.88, HighPrice: 8.88},
+					{OpenPrice: 8.88, ClosePrice: 8.88, LowPrice: 8.88, HighPrice: 8.88},
+				},
+			},
+		},
+		{
+			Instrument:   &roho.Instrument{Symbol: "sell-downward-position"},
+			Position:     &roho.Position{Quantity: 2, AverageBuyPrice: 7.00},
+			Quote:        &roho.Quote{BidPrice: 8.84},
+			Fundamentals: &roho.Fundamental{High52Weeks: 8.88},
+			Historical: &roho.Historical{
+				Records: []roho.HistoricalRecord{
+					{OpenPrice: 8.88, HighPrice: 8.88, LowPrice: 8.87, ClosePrice: 8.87},
+					{OpenPrice: 8.87, HighPrice: 8.87, LowPrice: 8.86, ClosePrice: 8.86},
+					{OpenPrice: 8.86, HighPrice: 8.86, LowPrice: 8.85, ClosePrice: 8.85},
+					{OpenPrice: 8.85, HighPrice: 8.85, LowPrice: 8.84, ClosePrice: 8.84},
+				},
+			},
+		},
+		{
+			Instrument:   &roho.Instrument{Symbol: "hold-upward-position"},
+			Position:     &roho.Position{Quantity: 2, AverageBuyPrice: 7.00},
+			Quote:        &roho.Quote{BidPrice: 8.88},
+			Fundamentals: &roho.Fundamental{High52Weeks: 8.88},
+			Historical: &roho.Historical{
+				Records: []roho.HistoricalRecord{
+					{OpenPrice: 8.84, LowPrice: 8.84, HighPrice: 8.85, ClosePrice: 8.85},
+					{OpenPrice: 8.85, LowPrice: 8.85, HighPrice: 8.86, ClosePrice: 8.86},
+					{OpenPrice: 8.86, LowPrice: 8.86, HighPrice: 8.87, ClosePrice: 8.87},
+				},
+			},
+		},
+		{
+			Instrument:   &roho.Instrument{Symbol: "wait-stalled-option"},
+			Quote:        &roho.Quote{AskPrice: 8.88},
+			Fundamentals: &roho.Fundamental{Low52Weeks: 8.88},
+			Historical: &roho.Historical{
+				Records: []roho.HistoricalRecord{
+					{OpenPrice: 8.88, ClosePrice: 8.88, LowPrice: 8.88, HighPrice: 8.88},
+					{OpenPrice: 8.88, ClosePrice: 8.88, LowPrice: 8.88, HighPrice: 8.88},
+					{OpenPrice: 8.88, ClosePrice: 8.88, LowPrice: 8.88, HighPrice: 8.88},
+					{OpenPrice: 8.88, ClosePrice: 8.88, LowPrice: 8.88, HighPrice: 8.88},
+					{OpenPrice: 8.88, ClosePrice: 8.88, LowPrice: 8.88, HighPrice: 8.88},
+				},
+			},
+		},
+		{
+			Instrument:   &roho.Instrument{Symbol: "wait-downward-option"},
+			Quote:        &roho.Quote{AskPrice: 8.83},
+			Fundamentals: &roho.Fundamental{Low52Weeks: 8.88},
+			Historical: &roho.Historical{
+				Records: []roho.HistoricalRecord{
+					{OpenPrice: 8.88, HighPrice: 8.88, LowPrice: 8.87, ClosePrice: 8.87},
+					{OpenPrice: 8.87, HighPrice: 8.87, LowPrice: 8.86, ClosePrice: 8.86},
+					{OpenPrice: 8.86, HighPrice: 8.86, LowPrice: 8.85, ClosePrice: 8.85},
+					{OpenPrice: 8.85, HighPrice: 8.85, LowPrice: 8.84, ClosePrice: 8.84},
+				},
+			},
+		},
+		{
+			Instrument:   &roho.Instrument{Symbol: "buy-upward-option"},
+			Quote:        &roho.Quote{AskPrice: 8.94},
+			Fundamentals: &roho.Fundamental{Low52Weeks: 8.88},
+			Historical: &roho.Historical{
+				Records: []roho.HistoricalRecord{
+					{OpenPrice: 8.84, LowPrice: 8.84, HighPrice: 8.85, ClosePrice: 8.85},
+					{OpenPrice: 8.85, LowPrice: 8.85, HighPrice: 8.86, ClosePrice: 8.86},
+					{OpenPrice: 8.86, LowPrice: 8.86, HighPrice: 8.87, ClosePrice: 8.87},
+				},
+			},
+		},
+		{
+			Instrument:   &roho.Instrument{Symbol: "ignore-far"},
+			Quote:        &roho.Quote{BidPrice: 9.15, AskPrice: 9.15},
+			Fundamentals: &roho.Fundamental{Low52Weeks: 8.88, High52Weeks: 9.99},
+			Historical: &roho.Historical{
+				Records: []roho.HistoricalRecord{
+					{OpenPrice: 8.88},
+				},
+			},
+		},
+	}
+
+	want := []Trade{
+		{Instrument: &roho.Instrument{Symbol: "sell-downward-position"}, Order: roho.OrderOpts{Price: 8.84, Quantity: 2, Side: roho.Sell}, Reason: `0.5% away from 52-week high of 8.88, -0.34% bounce`},
+		{Instrument: &roho.Instrument{Symbol: "buy-upward-option"}, Order: roho.OrderOpts{Price: 8.94, Quantity: 1, Side: roho.Buy}, Reason: "0.7% away from 52wk low of 8.88, 1.13% bounce"},
+	}
+	got, err := s.Trades(context.Background(), cs)
+	if err != nil {
+		t.Errorf("Trades() returned unexpected error: %v", err)
+	}
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("unexpected trade diff: %s", diff)
+	}
+}
+
+func TestUpward(t *testing.T) {
+	tests := []struct {
+		input    []float64
+		wantOK   bool
+		wantPerc float64
+	}{
+		{input: []float64{2, 2, 3, 4}, wantOK: true, wantPerc: 100.0},
+		{input: []float64{2, 2, 1, 4}, wantOK: false, wantPerc: 100.0},
+		{input: []float64{0.1, 0.2, 0.2, 0.3}, wantOK: true, wantPerc: 200},
+		{input: []float64{100, 100, 101, 101}, wantOK: true, wantPerc: 1},
+	}
+
+	for _, tc := range tests {
+		ok, perc := upward(tc.input)
+		if ok != tc.wantOK {
+			t.Errorf("upward(%v).ok = %v, want %v", tc.input, ok, tc.wantOK)
+		}
+		if math.Abs(percentDiff(perc, tc.wantPerc)) > 0.001 && fmt.Sprintf("%.3f", perc) != fmt.Sprintf("%.3f", tc.wantPerc) {
+			t.Errorf("upward(%v).perc = %.3f, want %.3f", tc.input, perc, tc.wantPerc)
+		}
+	}
+}

--- a/pkg/strategy/hilo.go
+++ b/pkg/strategy/hilo.go
@@ -25,8 +25,7 @@ func (cr *HiLoStrategy) Trades(_ context.Context, cs []*CombinedStock) ([]Trade,
 
 		// Buy stock only if we do not yet own it
 		if p == nil {
-			ratio := s.Fundamentals.Low52Weeks / s.Quote.AskPrice
-			perc := 100 - (ratio * 100)
+			perc := percentDiff(s.Fundamentals.Low52Weeks, s.Quote.AskPrice)
 			if perc < 2 {
 				klog.Infof("%s: ask price of %.2f is %.2f%% away from 52-week low of %.2f", s.Instrument.Symbol, s.Quote.AskPrice, perc, s.Fundamentals.Low52Weeks)
 			}
@@ -46,8 +45,7 @@ func (cr *HiLoStrategy) Trades(_ context.Context, cs []*CombinedStock) ([]Trade,
 			continue
 		}
 
-		ratio := s.Quote.BidPrice / s.Fundamentals.High52Weeks
-		perc := 100 - (ratio * 100)
+		perc := percentDiff(s.Quote.BidPrice, s.Fundamentals.High52Weeks)
 
 		if perc < 2 {
 			klog.Infof("%s: bad price of %.2f is %.2f%% away from 52-week high of %.2f", s.Instrument.Symbol, s.Quote.BidPrice, perc, s.Fundamentals.High52Weeks)
@@ -75,4 +73,8 @@ func (cr *HiLoStrategy) Trades(_ context.Context, cs []*CombinedStock) ([]Trade,
 	}
 
 	return ts, nil
+}
+
+func percentDiff(old, n float64) float64 {
+	return ((n - old) / old) * 100
 }

--- a/pkg/strategy/hilo_test.go
+++ b/pkg/strategy/hilo_test.go
@@ -2,6 +2,7 @@ package strategy
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -63,5 +64,23 @@ func TestHiLo(t *testing.T) {
 
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("unexpected trade diff: %s", diff)
+	}
+}
+
+func TestPercentDiff(t *testing.T) {
+	tests := []struct {
+		a    float64
+		b    float64
+		want float64
+	}{
+		{100, 80, -20},
+		{4, 5, 25},
+	}
+
+	for _, tc := range tests {
+		got := percentDiff(tc.a, tc.b)
+		if fmt.Sprintf("%.3f", got) != fmt.Sprintf("%.3f", tc.want) {
+			t.Errorf("percentDiff(%v, %v) = %.3f, want %.3f", tc.a, tc.b, got, tc.want)
+		}
 	}
 }

--- a/pkg/strategy/strategy.go
+++ b/pkg/strategy/strategy.go
@@ -11,6 +11,7 @@ var (
 	LuckySevens = "lucky-sevens"
 	Random      = "random"
 	HiLo        = "hilo"
+	Bounce      = "bounce"
 	strategies  = []string{LuckySevens, Random, HiLo}
 )
 
@@ -51,6 +52,9 @@ func New(c Config) (Strategy, error) {
 		return l, nil
 	case HiLo:
 		l := &HiLoStrategy{c: c}
+		return l, nil
+	case Bounce:
+		l := &BounceStrategy{c: c}
 		return l, nil
 	default:
 		return nil, fmt.Errorf("no strategy named %q exists", c.Kind)


### PR DESCRIPTION
BounceStrategy is a demonstration strategy to buy/sell stocks when they change direction near their 52-week hi/low

This is the first strategy that uses historical data.

